### PR TITLE
Add output.ctest_out files

### DIFF
--- a/testsetup/run_test.cmake
+++ b/testsetup/run_test.cmake
@@ -41,6 +41,8 @@ execute_process(
     ERROR_VARIABLE _out
     WORKING_DIRECTORY test_runs/${TEST_NAME})
 
+file(WRITE test_runs/${TEST_NAME}/${TEST_NAME}.ctest_out ${_out})
+
 if (test_execution_not_successful)
     message(STATUS "test_execution_not_successful: ${test_execution_not_successful}")
     message(STATUS "_out: ${_out}")


### PR DESCRIPTION
Keep the OpenCMISS output as a .ctest_out file.

Addresses part of https://github.com/OpenCMISS/functional_test_framework/issues/5